### PR TITLE
chore: apply org-standard automation files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,27 +27,14 @@ Breaking changes: add `!` after type or `BREAKING CHANGE:` in footer.
 
 ### Release Pipeline
 
-We use a **reusable release workflow** from `plures/.github`:
+This repository uses a release workflow defined in `.github/workflows/release.yml`.
 
-```yaml
-name: Release
-on:
-  push:
-    branches: [main]
-  workflow_dispatch:
-    inputs:
-      bump:
-        type: choice
-        options: [patch, minor, major]
-jobs:
-  release:
-    uses: plures/.github/.github/workflows/release-reusable.yml@main
-    with:
-      bump: ${{ inputs.bump || '' }}
-    secrets: inherit
-```
+- Treat that workflow file as the **source of truth** for triggers, inputs (for example `release_type`, including any `prerelease` option), and job behavior.
+- Do **not** assume it uses the reusable workflow from `plures/.github` — always check this repo’s `release.yml` before making changes.
+- Follow the organization-wide guidance in the development guide for release practices and expectations:
+  - https://github.com/plures/development-guide (see the CI/CD & Releases sections)
 
-The pipeline auto-detects project type and publishes to the appropriate registry.
+The pipeline is responsible for publishing artifacts and managing versioning according to our conventional commit rules.
 Version bumps are automatic from conventional commits. Do NOT manually bump versions.
 
 ### What NOT to Do


### PR DESCRIPTION
## Org Standards Enforcement

This PR adds missing standard automation files:

- `.github/copilot-instructions.md` — Copilot coding instructions

These are required by the plures org standards. See [development-guide](https://github.com/plures/development-guide) for details.

---
_Auto-generated by [repo-standards](https://github.com/plures/.github/blob/main/.github/workflows/repo-standards.yml)_